### PR TITLE
169262649 incluir base card material

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3010,6 +3010,11 @@
         "fontfaceobserver": "^2.1.0"
       }
     },
+    "expo-image-picker": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/expo-image-picker/-/expo-image-picker-6.0.0.tgz",
+      "integrity": "sha512-7IW4WxDe0xQclGhTnX3DOgTkMvt2kF/MNOPbk2y9fS5k/8am9I8jErjURPxRUGH7+TvYLEWPy63DRAJP7TYyEg=="
+    },
     "expo-keep-awake": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/expo-keep-awake/-/expo-keep-awake-6.0.0.tgz",

--- a/src/screens/EntradaMateriais/EntradaMateriais.tsx
+++ b/src/screens/EntradaMateriais/EntradaMateriais.tsx
@@ -10,6 +10,7 @@ const materiais = [
         nome: 'Fluorescente FL',
         tensao: '227V',
         potencia: '150W',
+        base: 'E27',
         quantidade: '20'
     },
     {
@@ -18,6 +19,7 @@ const materiais = [
         nome: 'Fluorescente FL',
         tensao: '110V',
         potencia: '150W',
+        base: 'MR11',
         quantidade: ''
     },
     {
@@ -26,6 +28,7 @@ const materiais = [
         nome: 'Fluorescente FL',
         tensao: '227V',
         potencia: '50W',
+        base: 'MR16',
         quantidade: ''
     },
     {
@@ -34,6 +37,7 @@ const materiais = [
         nome: 'Fluorescente FL',
         tensao: '227V',
         potencia: '150W',
+        base: null,
         quantidade: null
     }
 ]
@@ -77,6 +81,7 @@ export default class EntradaMateriais extends Component {
                                                 <Text>Tipo: {material.tipo}</Text>
                                                 <Text>Potência: {material.potencia}</Text>
                                                 <Text>Tensão: {material.tensao}</Text>
+                                                <Text>Base: {material.base}</Text>
                                             </Body>
                                         </CardItem>
                                         <CardItem footer bordered>

--- a/src/screens/Estoque/Estoque.tsx
+++ b/src/screens/Estoque/Estoque.tsx
@@ -10,6 +10,7 @@ const materiais = [
         nome: 'Fluorescente FL',
         tensao: '227V',
         potencia: '150W',
+        base: 'E27',
         quantidade: '20'
     },
     {
@@ -18,6 +19,7 @@ const materiais = [
         nome: 'Fluorescente FL',
         tensao: '110V',
         potencia: '150W',
+        base: 'MR11',
         quantidade: ''
     },
     {
@@ -26,6 +28,7 @@ const materiais = [
         nome: 'Fluorescente FL',
         tensao: '227V',
         potencia: '50W',
+        base: 'MR16',
         quantidade: ''
     },
     {
@@ -34,6 +37,7 @@ const materiais = [
         nome: 'Fluorescente FL',
         tensao: '227V',
         potencia: '150W',
+        base: null,
         quantidade: null
     }
 ]

--- a/src/screens/Estoque/Estoque.tsx
+++ b/src/screens/Estoque/Estoque.tsx
@@ -81,6 +81,7 @@ export default class Estoque extends Component {
                                                 <Text>Tipo: {material.tipo}</Text>
                                                 <Text>Potência: {material.potencia}</Text>
                                                 <Text>Tensão: {material.tensao}</Text>
+                                                <Text>Base: {material.base}</Text>
                                             </Body>
                                         </CardItem>
                                         <CardItem footer bordered>

--- a/src/screens/ManutencaoIluminacao/ManutencaoItem.tsx
+++ b/src/screens/ManutencaoIluminacao/ManutencaoItem.tsx
@@ -10,6 +10,7 @@ const materiais = [
         nome: 'Fluorescente FL',
         tensao: '227V',
         potencia: '150W',
+        base: 'E27',
         quantidade: '20'
     },
     {
@@ -18,6 +19,7 @@ const materiais = [
         nome: 'Fluorescente FL',
         tensao: '110V',
         potencia: '150W',
+        base: 'MR11',
         quantidade: ''
     },
     {
@@ -26,6 +28,7 @@ const materiais = [
         nome: 'Fluorescente FL',
         tensao: '227V',
         potencia: '50W',
+        base: 'MR16',
         quantidade: ''
     },
     {
@@ -34,6 +37,7 @@ const materiais = [
         nome: 'Fluorescente FL',
         tensao: '227V',
         potencia: '150W',
+        base: null,
         quantidade: null
     }
 ]
@@ -61,6 +65,7 @@ export function ManutencaoItem(props) {
                                         <Text>Tipo: {material.tipo}</Text>
                                         <Text>Potência: {material.potencia}</Text>
                                         <Text>Tensão: {material.tensao}</Text>
+                                        <Text>Base: {material.base}</Text>
                                     </Body>
                                 </CardItem>
                                 <CardItem footer bordered>


### PR DESCRIPTION
[Link Pivotal](https://www.pivotaltracker.com/story/show/169262649)
----

- Incluindo campo `base` no mock de materiais em Estoque, Entrada de Material e Manutenção Iluminação
- Incluindo o campo no corpo do card de um Material

:+1: