### PR TITLE
Teste/qrcode

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,6 +14,7 @@ import MenuVistoria from "./screens/MenuVistoria/MenuVistoria";
 import EstoqueScreen from "./screens/Estoque/Estoque";
 import EntradaMateriais from "./screens/EntradaMateriais/EntradaMateriais";
 import ManutencaoIluminacao from "./screens/ManutencaoIluminacao/ManutencaoIluminacao";
+import ScanQRCodeReader from "./screens/ManutencaoIluminacao/ScanQRCodeReader";
 import ComentariosGerais from "./screens/ComentariosGerais/ComentariosGerais";
 import ManutencaoItem from "./screens/ManutencaoIluminacao/ManutencaoItem";
 import Colaboradores from "./screens/Colaboradores/Colaboradores";
@@ -30,6 +31,7 @@ const AuthStack = createStackNavigator(
     Estoque: { screen: EstoqueScreen },
     EntradaMateriais: { screen: EntradaMateriais },
     ManutencaoIluminacao: { screen: ManutencaoIluminacao },
+    ScanQRCodeReader: { screen: ScanQRCodeReader },
     ManutencaoItem: { screen: ManutencaoItem },
     FotosItem: { screen: FotosItemScreen },
     ComentariosGerais: { screen: ComentariosGerais },

--- a/src/components/QRCodeReader.tsx
+++ b/src/components/QRCodeReader.tsx
@@ -1,9 +1,10 @@
 import React, { useState, useEffect } from 'react';
-import { Text, StyleSheet, Button } from 'react-native';
+import { Text, StyleSheet, Button, ActivityIndicator } from 'react-native';
 import { View } from "native-base";
 import { BarCodeScanner } from "expo-barcode-scanner";
 import { TouchableHighlight, Dimensions } from "react-native";
 import { FontAwesome } from "@expo/vector-icons";
+  
 
 export function QRCodeReader(props) {
     
@@ -11,7 +12,7 @@ export function QRCodeReader(props) {
 
     const handleBarCodeScanned = ({ type, data }) => {
         setScanned(true);
-        alert(`QRCODE ${data} ENCONTRADO. FAVOR AGUARDAR O ITEM SER CARREGADO`);
+        alert(`QRCODE ${data} ESCANEADO. FAVOR AGUARDAR!!`);
         const { navigation } = props;
         const qrcode = data;
         navigation.navigate({ routeName: 'ManutencaoItem', params: { qrcode }})
@@ -20,21 +21,39 @@ export function QRCodeReader(props) {
 
     var {height} = Dimensions.get('window');
 
-    return <View style={{zIndex:9, position: 'absolute', backgroundColor: 'black', top: 0, left: 0, right: 0, bottom: 0, justifyContent: 'flex-start', alignItems: 'flex-start', height: height}}>
-        <BarCodeScanner
-        onBarCodeScanned={scanned ? undefined : handleBarCodeScanned}
-        style={StyleSheet.absoluteFillObject}
-        />
-
-        {/* <TouchableHighlight 
-        onPress={() => props.handleClose}
-        style={{ zIndex: 10, alignSelf: 'flex-start', position: 'absolute', top: 0, left: 10, padding: 10}}
-        >
-        <FontAwesome
-            name="arrow-left"
-            size={36}
-            color='white'            
+    
+    return (
+    
+        <View style={{zIndex:9, position: 'absolute', backgroundColor: 'black', top: 0, left: 0, right: 0, bottom: 0, justifyContent: 'flex-start', alignItems: 'flex-start', height: height}}>
+            
+            <BarCodeScanner
+            onBarCodeScanned={scanned ? undefined : handleBarCodeScanned}
+            style={StyleSheet.absoluteFillObject}
             />
-        </TouchableHighlight> */}
-    </View>
+
+            {/* <TouchableHighlight 
+            onPress={() => props.handleClose}
+            style={{ zIndex: 10, alignSelf: 'flex-start', position: 'absolute', top: 0, left: 10, padding: 10}}
+            >
+            <FontAwesome
+                name="arrow-left"
+                size={36}
+                color='white'            
+                />
+            </TouchableHighlight> */}
+        </View>
+    );
+
+    
 }
+
+const styles = {
+    container: {
+      flexGrow: 1
+    },
+    spinner: {
+      flex: 1,
+      justifyContent: 'center',
+      alignItems: 'center'
+    }
+  };

--- a/src/components/QRCodeReader.tsx
+++ b/src/components/QRCodeReader.tsx
@@ -11,17 +11,14 @@ export function QRCodeReader(props) {
 
     const handleBarCodeScanned = ({ type, data }) => {
         setScanned(true);
-        alert(`Bar code with type ${type} and data ${data} has been scanned!`);
-        console.log('qrcode scanned');
+        alert(`QRCODE ${data} ENCONTRADO. FAVOR AGUARDAR O ITEM SER CARREGADO`);
         const { navigation } = props;
         const qrcode = data;
-        console.log('qrcode', qrcode);        
         navigation.navigate({ routeName: 'ManutencaoItem', params: { qrcode }})
     };
 
 
     var {height} = Dimensions.get('window');
-    const { navigation } = props;
 
     return <View style={{zIndex:9, position: 'absolute', backgroundColor: 'black', top: 0, left: 0, right: 0, bottom: 0, justifyContent: 'flex-start', alignItems: 'flex-start', height: height}}>
         <BarCodeScanner

--- a/src/components/QRCodeReader.tsx
+++ b/src/components/QRCodeReader.tsx
@@ -1,25 +1,43 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
+import { Text, StyleSheet, Button } from 'react-native';
 import { View } from "native-base";
 import { BarCodeScanner } from "expo-barcode-scanner";
 import { TouchableHighlight, Dimensions } from "react-native";
 import { FontAwesome } from "@expo/vector-icons";
 
 export function QRCodeReader(props) {
+    
+    const [scanned, setScanned] = useState(false);
+
+    const handleBarCodeScanned = ({ type, data }) => {
+        setScanned(true);
+        alert(`Bar code with type ${type} and data ${data} has been scanned!`);
+        console.log('qrcode scanned');
+        const { navigation } = props;
+        const qrcode = data;
+        console.log('qrcode', qrcode);        
+        navigation.navigate({ routeName: 'ManutencaoItem', params: { qrcode }})
+    };
+
+
     var {height} = Dimensions.get('window');
+    const { navigation } = props;
+
     return <View style={{zIndex:9, position: 'absolute', backgroundColor: 'black', top: 0, left: 0, right: 0, bottom: 0, justifyContent: 'flex-start', alignItems: 'flex-start', height: height}}>
         <BarCodeScanner
-        onBarCodeScanned={props.handleScan}
-        style={{position: 'absolute', alignSelf: 'flex-start', top: 0, left: 0, right: 0, bottom: 0}}
+        onBarCodeScanned={scanned ? undefined : handleBarCodeScanned}
+        style={StyleSheet.absoluteFillObject}
         />
-        <TouchableHighlight 
+
+        {/* <TouchableHighlight 
         onPress={() => props.handleClose}
         style={{ zIndex: 10, alignSelf: 'flex-start', position: 'absolute', top: 0, left: 10, padding: 10}}
         >
         <FontAwesome
             name="arrow-left"
             size={36}
-            color='white'
+            color='white'            
             />
-        </TouchableHighlight>
+        </TouchableHighlight> */}
     </View>
 }

--- a/src/components/QRCodeReader.tsx
+++ b/src/components/QRCodeReader.tsx
@@ -1,18 +1,17 @@
-import React, { useState, useEffect } from 'react';
-import { Text, StyleSheet, Button, ActivityIndicator } from 'react-native';
+import React, { useState } from 'react';
+import { StyleSheet } from 'react-native';
 import { View } from "native-base";
 import { BarCodeScanner } from "expo-barcode-scanner";
-import { TouchableHighlight, Dimensions } from "react-native";
-import { FontAwesome } from "@expo/vector-icons";
-  
+import { Dimensions } from "react-native";
+
 
 export function QRCodeReader(props) {
-    
+
     const [scanned, setScanned] = useState(false);
 
-    const handleBarCodeScanned = ({ type, data }) => {
+    const handleBarCodeScanned = ({ data }) => {
         setScanned(true);
-        alert(`QRCODE ${data} ESCANEADO. FAVOR AGUARDAR!!`);
+        alert(`Código escaneado: ${data}. Aguarde enquanto as informações são carregadas.`);
         const { navigation } = props;
         const qrcode = data;
         navigation.navigate({ routeName: 'ManutencaoItem', params: { qrcode }})
@@ -21,39 +20,16 @@ export function QRCodeReader(props) {
 
     var {height} = Dimensions.get('window');
 
-    
+
     return (
-    
+
         <View style={{zIndex:9, position: 'absolute', backgroundColor: 'black', top: 0, left: 0, right: 0, bottom: 0, justifyContent: 'flex-start', alignItems: 'flex-start', height: height}}>
-            
             <BarCodeScanner
             onBarCodeScanned={scanned ? undefined : handleBarCodeScanned}
             style={StyleSheet.absoluteFillObject}
             />
-
-            {/* <TouchableHighlight 
-            onPress={() => props.handleClose}
-            style={{ zIndex: 10, alignSelf: 'flex-start', position: 'absolute', top: 0, left: 10, padding: 10}}
-            >
-            <FontAwesome
-                name="arrow-left"
-                size={36}
-                color='white'            
-                />
-            </TouchableHighlight> */}
         </View>
     );
 
-    
-}
 
-const styles = {
-    container: {
-      flexGrow: 1
-    },
-    spinner: {
-      flex: 1,
-      justifyContent: 'center',
-      alignItems: 'center'
-    }
-  };
+}

--- a/src/screens/Login/Login.tsx
+++ b/src/screens/Login/Login.tsx
@@ -31,8 +31,8 @@ interface State {
 class Login extends Component<Props, State> {
 
   state = {
-    user: 'renato.gomes',
-    password: '12344321',
+    user: '',
+    password: '',
     auth: {
       loading: false,
       error: false,

--- a/src/screens/ManutencaoIluminacao/ManutencaoIluminacao.tsx
+++ b/src/screens/ManutencaoIluminacao/ManutencaoIluminacao.tsx
@@ -31,6 +31,7 @@ class ManutencaoIluminacao extends Component<Props> {
         hasCameraPermission: false,
         readingQRCode: false,
         loadingConcluir: false,
+        scanned: false
     }
 
     async componentDidMount() {
@@ -40,7 +41,7 @@ class ManutencaoIluminacao extends Component<Props> {
     }
 
     componentDidUpdate(prevProps: Props) {
-      if (prevProps.isFocused !== this.props.isFocused) {
+      if (prevProps.isFocused !== this.props.isFocused) {        
         this.carregaItens();
       }
     }
@@ -67,12 +68,6 @@ class ManutencaoIluminacao extends Component<Props> {
     ativaQRCodeReader() {
         this.setState({
             readingQRCode: true
-        })
-    }
-
-    handleCloseQRCode() {
-        this.setState({
-            readingQRCode: false,
         })
     }
 
@@ -106,29 +101,18 @@ class ManutencaoIluminacao extends Component<Props> {
       navigation.navigate('Menu');
     }
 
-    handleScan(scannedObj) {
-        console.log('qrcode scanned');
-        const { navigation } = this.props;
-        const qrcode = scannedObj.data;
-        console.log('qrcode', qrcode);
-        this.setState({
-            qrcode,
-            readingQRCode: false,
-        })
-        navigation.navigate({ routeName: 'ManutencaoItem', params: { qrcode }})
-    }
-
     openItem = (item: Item) => {
       const { navigation } = this.props;
       navigation.navigate({ routeName: 'ManutencaoItem', params: { idItem: item.id } })
     }
 
     render() {
-      const { readingQRCode, itens, loadingConcluir } = this.state;
+      const { readingQRCode, itens, loadingConcluir, scanned } = this.state;
+      const { navigation } = this.props;
       if (readingQRCode) {
         return <QRCodeReader
-          handleClose={() => this.handleCloseQRCode()}
-          handleScan={e => this.handleScan(e)} />
+          navigation={navigation}
+           />
       }
 
       return (

--- a/src/screens/ManutencaoIluminacao/ManutencaoIluminacao.tsx
+++ b/src/screens/ManutencaoIluminacao/ManutencaoIluminacao.tsx
@@ -8,7 +8,7 @@ import * as ProgramacoesActions from '../../store/ducks/programacoes/actions'
 import { bindActionCreators, Dispatch } from 'redux';
 import { connect } from 'react-redux';
 import { Planta, Item } from '../../store/ducks/planta/types';
-import { QRCodeReader } from '../../components/QRCodeReader';
+
 import { NavigationScreenProp, withNavigationFocus } from 'react-navigation';
 import { ProgramacaoRealizada } from '../../store/ducks/programacoes/types';
 
@@ -66,9 +66,8 @@ class ManutencaoIluminacao extends Component<Props> {
     }
 
     ativaQRCodeReader() {
-        this.setState({
-            readingQRCode: true
-        })
+      const { navigation } = this.props;
+      navigation.navigate('ScanQRCodeReader');
     }
 
     concluirManutencao = () => {
@@ -107,13 +106,8 @@ class ManutencaoIluminacao extends Component<Props> {
     }
 
     render() {
-      const { readingQRCode, itens, loadingConcluir, scanned } = this.state;
-      const { navigation } = this.props;
-      if (readingQRCode) {
-        return <QRCodeReader
-          navigation={navigation}
-           />
-      }
+      const { itens, loadingConcluir } = this.state;
+      
 
       return (
         <Container>

--- a/src/screens/ManutencaoIluminacao/ManutencaoItem.tsx
+++ b/src/screens/ManutencaoIluminacao/ManutencaoItem.tsx
@@ -195,7 +195,7 @@ class ManutencaoItem extends Component<Props> {
 
     if (error) {
       return <Container>
-        <HeaderNav title={nome} />
+        <HeaderNav title={'MANUTENÇÃO'} />
         <Content padder>
           <Text>{error}</Text>
         </Content>
@@ -205,7 +205,7 @@ class ManutencaoItem extends Component<Props> {
 
     return (
       <Container>
-        <HeaderNav title={nome} />
+        <HeaderNav title={'MANUTENÇÃO'} />
         <Content padder>
           <KeyboardAvoidingView
             behavior="height"
@@ -216,6 +216,7 @@ class ManutencaoItem extends Component<Props> {
                   <Thumbnail source={require('../../../assets/qrcode.png')} />
                   <Body>
                     <Text note>{qrcode}</Text>
+                    <Text note>{nome}</Text>
                     <Badge
                       warning={emergencia}
                       primary={!emergencia}>

--- a/src/screens/ManutencaoIluminacao/ScanQRCodeReader.tsx
+++ b/src/screens/ManutencaoIluminacao/ScanQRCodeReader.tsx
@@ -7,13 +7,17 @@ import {
   View,
 } from 'react-native'
 
-interface StateProps {
+interface ScanProps {
   navigation: NavigationScreenProp<any, any>,
 }
 
-type Props = StateProps
+type ScanState = {
+  isFocused: boolean;
+}
 
-class ScanQRCodeReader extends Component<Props> {
+type Props = ScanProps
+
+class ScanQRCodeReader extends Component<Props,ScanState> {
 
     constructor(props) {
       super(props);
@@ -33,7 +37,7 @@ class ScanQRCodeReader extends Component<Props> {
         () => this.setState({ isFocused: false }),
       );
     }
-    
+
     componentWillUnmount() {
       this.focusListner.remove();
       this.blurListner.remove();
@@ -53,7 +57,7 @@ class ScanQRCodeReader extends Component<Props> {
       return <QRCodeReader
         navigation={navigation}
           />
-      
+
     }
 }
 

--- a/src/screens/ManutencaoIluminacao/ScanQRCodeReader.tsx
+++ b/src/screens/ManutencaoIluminacao/ScanQRCodeReader.tsx
@@ -1,0 +1,71 @@
+import React, { Component } from 'react';
+import { NavigationScreenProp } from 'react-navigation';
+import { QRCodeReader } from '../../components/QRCodeReader';
+
+import {
+  ActivityIndicator,
+  View,
+} from 'react-native'
+
+interface StateProps {
+  navigation: NavigationScreenProp<any, any>,
+}
+
+type Props = StateProps
+
+class ScanQRCodeReader extends Component<Props> {
+
+    constructor(props) {
+      super(props);
+
+      this.state = {
+        isFocused: false
+      };
+    }
+
+    componentDidMount() {
+      this.focusListner = this.props.navigation.addListener(
+        'didFocus',
+        () => this.setState({ isFocused: true }),
+      );
+      this.blurListner = this.props.navigation.addListener(
+        'willBlur',
+        () => this.setState({ isFocused: false }),
+      );
+    }
+    
+    componentWillUnmount() {
+      this.focusListner.remove();
+      this.blurListner.remove();
+    }
+
+    render() {
+
+      const { navigation } = this.props;
+
+      if (!this.state.isFocused) {
+        return (
+          <View contentContainerStyle={styles.container} style={styles.spinner}>
+            <ActivityIndicator size='large' />
+          </View>
+        );
+      }
+      return <QRCodeReader
+        navigation={navigation}
+          />
+      
+    }
+}
+
+const styles = {
+  container: {
+    flexGrow: 1
+  },
+  spinner: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center'
+  }
+};
+
+export default ScanQRCodeReader;


### PR DESCRIPTION
Com base em alguns artigos que li, e na própria doc do Expo, alterei o comportamento do QRCode e tentei trazer alguma UX pros técnicos.
Parece que o problema de performance ocorria por causa do tratamento da variavel "readingQRCode", aí separei o leitor do QRCode em uma tela separada e só chamo ela quando aperto o botão, eliminando a necessidade de uma verificação do estado pra abrir ou não o QRCode.
Além disso, conforme própria doc do Expo, deve-se passar undefined pra uma prop do barcodescanner quando houver escaneamento, pra ele não continuar escaneando.